### PR TITLE
Fix CLI by passing on parameters

### DIFF
--- a/com.steamgriddb.steam-rom-manager.json
+++ b/com.steamgriddb.steam-rom-manager.json
@@ -56,7 +56,7 @@
                     "type": "script",
                     "dest-filename": "run.sh",
                     "commands": [
-                        "/app/bin/zypak-wrapper.sh /app/srm/steam-rom-manager"
+                        "/app/bin/zypak-wrapper.sh /app/srm/steam-rom-manager $@"
                     ]
                 },
                 {


### PR DESCRIPTION
This should fix https://github.com/SteamGridDB/steam-rom-manager/issues/710 at least for the Flatpak build.