### PR TITLE
Why does it need access to all host data?

### DIFF
--- a/com.steamgriddb.steam-rom-manager.json
+++ b/com.steamgriddb.steam-rom-manager.json
@@ -15,7 +15,8 @@
         "--socket=pulseaudio",
         "--share=network",
         "--device=all",
-        "--filesystem=host",
+        "--filesystem=~/.var/app/com.valvesoftware.Steam/.steam/steam",
+        "--filesystem=~/.steam/steam",
         "--env=IN_FLATPAK=1"
     ],
     "cleanup": [


### PR DESCRIPTION
The `host` permission is quite huge, why does it need that? Would not this be enough?

I took it from this very similar app that can also operate on that: https://github.com/flathub/io.github.Foldex.AdwSteamGtk/blob/fed9b330eab2729e81730afb6c85dd1c7c9a4209/io.github.Foldex.AdwSteamGtk.json#L13-L14